### PR TITLE
Integrate keboola.vcr, migrate to src layout, and revamp functional test CLI

### DIFF
--- a/src/keboola/datadirtest/__main__.py
+++ b/src/keboola/datadirtest/__main__.py
@@ -178,12 +178,6 @@ def create_parser():
         action="store_true",
         help="Delete all existing cassettes and re-record from live API",
     )
-    scaffold_parser.add_argument(
-        "--add-missing-cassettes",
-        action="store_true",
-        help="Only record cassettes for tests that don't have one yet",
-    )
-
     # Snapshot subcommand
     snapshot_parser = subparsers.add_parser(
         "snapshot",

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -153,6 +153,13 @@ class VCRTestDataDir(TestDataDir):
                     logger.info(f"No cassette and no secrets for {self.id()}, running without VCR")
                     super().run_component()
 
+        if (
+            self.vcr_recorder
+            and self.vcr_recorder.last_log_comparison
+            and not self.vcr_recorder.last_log_comparison.success
+        ):
+            self.fail(self.vcr_recorder.last_log_comparison.format_output(verbose=self.verbose))
+
     def compare_source_and_expected(self):
         """Execute and compare with optional snapshot validation."""
         super().compare_source_and_expected()

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -153,13 +153,6 @@ class VCRTestDataDir(TestDataDir):
                     logger.info(f"No cassette and no secrets for {self.id()}, running without VCR")
                     super().run_component()
 
-        if (
-            self.vcr_recorder
-            and self.vcr_recorder.last_log_comparison
-            and not self.vcr_recorder.last_log_comparison.success
-        ):
-            self.fail(self.vcr_recorder.last_log_comparison.format_output(verbose=self.verbose))
-
     def compare_source_and_expected(self):
         """Execute and compare with optional snapshot validation."""
         super().compare_source_and_expected()


### PR DESCRIPTION
## Summary

Most of the VCR core (recorder, sanitizers, validator, scaffolder) lives in the companion repo — see [keboola/python-vcr-tests#4](https://github.com/keboola/python-vcr-tests/pull/4). This PR wires that package into datadirtest and completes the surrounding infrastructure:

- **datadirtest VCR integration**: `VCRTestDataDir` and `VCRDataDirTester` wrap the existing `DataDirTester`/`TestDataDir` infrastructure with VCR recording/replay; `datadirtest.vcr` re-exports all `keboola.vcr` symbols for a single import surface
- **Functional test CLI** (`python -m datadirtest`): full rewrite with subcommands for running, recording, replaying, scaffolding, and updating cassettes; named args with sensible defaults (`./tests/functional`, `./src/component.py`)
- **Package restructuring**: migrated to `src` layout and `pyproject.toml`; replaced `setup.py` and `bitbucket-pipelines.yml` with `uv` build system and GitHub Actions (push + deploy workflows)
- **Minor fixes**: chained-test misdetection, `freeze_time` auto-resolution, data dir structure creation, `add_missing` kwarg delegation to scaffolder

## Test plan

- [ ] Run existing datadir tests — no regressions
- [ ] VCR record and replay modes work end-to-end against a real component
- [ ] `python -m datadirtest scaffold` produces a valid test skeleton
- [ ] PyPI publish workflow triggers on release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)