### PR TITLE
feat(vcr): auto-load VCR_SANITIZERS from component script

### DIFF
--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -107,7 +107,8 @@ class VCRTestDataDir(TestDataDir):
         """Initialize VCR recorder with test-specific config."""
         try:
             component_sanitizers = _load_vcr_sanitizers_from_script(self.component_script)
-            sanitizers = component_sanitizers + (self.vcr_sanitizers or []) or None
+            merged_sanitizers = component_sanitizers + (self.vcr_sanitizers or [])
+            sanitizers = merged_sanitizers or None
             self.vcr_recorder = VCRRecorder.from_test_dir(
                 test_data_dir=Path(self.source_data_dir),
                 freeze_time_at=self.vcr_freeze_time,

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -7,6 +7,8 @@ DataDirTester infrastructure with VCR recording/replay support.
 
 import json
 import logging
+import runpy
+import sys
 from pathlib import Path
 from typing import Literal
 
@@ -17,6 +19,29 @@ from keboola.vcr.validator import validate_output_snapshot
 from ..datadirtest import DataDirTester, TestDataDir
 
 logger = logging.getLogger(__name__)
+
+
+def _load_vcr_sanitizers_from_script(component_script: str) -> list[BaseSanitizer]:
+    """Load VCR_SANITIZERS defined at module level in the component script.
+
+    Uses runpy.run_path to execute the script in a probe context (not __main__),
+    then extracts the VCR_SANITIZERS global if present. The component directory
+    is temporarily added to sys.path so relative imports resolve correctly.
+
+    Returns an empty list if VCR_SANITIZERS is not defined or loading fails.
+    """
+    component_dir = str(Path(component_script).parent)
+    original_path = sys.path.copy()
+    try:
+        if component_dir not in sys.path:
+            sys.path.insert(0, component_dir)
+        globals_ = runpy.run_path(component_script, run_name="__vcr_probe__")
+        return globals_.get("VCR_SANITIZERS") or []
+    except Exception as e:
+        logger.debug(f"Could not load VCR_SANITIZERS from {component_script}: {e}")
+        return []
+    finally:
+        sys.path[:] = original_path
 
 
 class VCRTestDataDir(TestDataDir):
@@ -81,10 +106,12 @@ class VCRTestDataDir(TestDataDir):
     def _setup_vcr(self):
         """Initialize VCR recorder with test-specific config."""
         try:
+            component_sanitizers = _load_vcr_sanitizers_from_script(self.component_script)
+            sanitizers = component_sanitizers + (self.vcr_sanitizers or []) or None
             self.vcr_recorder = VCRRecorder.from_test_dir(
                 test_data_dir=Path(self.source_data_dir),
                 freeze_time_at=self.vcr_freeze_time,
-                sanitizers=self.vcr_sanitizers,
+                sanitizers=sanitizers,
             )
         except ImportError as e:
             logger.warning(f"VCR dependencies not installed: {e}")


### PR DESCRIPTION
## Summary

- `VCR_SANITIZERS` defined at module level in `component.py` are now automatically discovered and applied during both recording and replay
- Eliminates the need to duplicate sanitizer config in `test_functional.py` — the tester reads them directly from the component

## How it works

Added `_load_vcr_sanitizers_from_script()` which uses `runpy.run_path(..., run_name="__vcr_probe__")` to execute the component script in probe mode (skips `if __name__ == "__main__":`) and extracts the `VCR_SANITIZERS` global. The component directory is temporarily added to `sys.path` so relative imports resolve, and restored afterwards.

`VCRTestDataDir._setup_vcr()` now always calls this, prepending the component's sanitizers before any explicitly passed `vcr_sanitizers`. When `merge_sanitizers` lands in `keboola.vcr`, the combination step can be upgraded to use it.

## Before / After

**Before** — every component's `test_functional.py` had to duplicate sanitizers:
```python
from keboola.vcr import DefaultSanitizer, ResponseUrlSanitizer

VCR_SANITIZERS = [
    DefaultSanitizer(additional_sensitive_fields=["page_token"]),
    ResponseUrlSanitizer(...),
]

tester = VCRDataDirTester(..., vcr_sanitizers=VCR_SANITIZERS, ...)
```

**After** — minimal runner, sanitizers live only in `component.py`:
```python
tester = VCRDataDirTester(
    data_dir=FUNCTIONAL_DIR,
    component_script=COMPONENT_SCRIPT,
    selected_tests=[test_name],
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)