### PR TITLE
fix --component flag collision in scaffold subcommand

### DIFF
--- a/src/keboola/datadirtest/__main__.py
+++ b/src/keboola/datadirtest/__main__.py
@@ -139,7 +139,7 @@ def create_parser():
     scaffold_parser.add_argument(
         "--component",
         "--component-script",
-        dest="component_script",
+        dest="scaffold_component_script",
         default="src/component.py",
         required=False,
         help="Component script for recording (default: src/component.py)",
@@ -261,7 +261,7 @@ def run_scaffold(args):
 
     definitions_file = Path(args.definitions_file)
     output_dir = Path(args.output_dir)
-    component_script = Path(args.component_script)
+    component_script = Path(args.scaffold_component_script)
 
     if not args.no_record and not component_script.exists():
         print(f"Error: component script not found: {component_script}")


### PR DESCRIPTION
The scaffold subparser's `--component` flag uses `dest="component_script"`, the same as the top-level positional argument. argparse resolves the collision by applying the positional's default (`./src/component.py`) after the subparser sets its value, effectively ignoring the user-provided `--component` flag.

Fix: rename the scaffold subparser's dest to `scaffold_component_script` to eliminate the collision.