### PR TITLE
feat: assert VCR log and sync action comparisons in VCRTestDataDir

### DIFF
--- a/src/keboola/datadirtest/datadirtest.py
+++ b/src/keboola/datadirtest/datadirtest.py
@@ -365,6 +365,7 @@ class TestChainedDatadirTest(unittest.TestCase):
         test_data_dir_class: type[TestDataDir] = TestDataDir,
         artifact_current_destination: Literal["custom", "runs"] = "runs",
         save_output: bool = False,
+        **kwargs,
     ):
         """
         Args:
@@ -374,6 +375,7 @@ class TestChainedDatadirTest(unittest.TestCase):
             context_parameters (dict): Optional context parameters injected from the DirTester runner.
             artifact_current_destination (str): Optional artifact's destination. Accepts 'custom' or 'runs' Default runs
             save_output (bool): If True, saves the output of each test to results/--NAME-OF-THE-TEST--/data directory
+            **kwargs: Extra keyword arguments forwarded to each sub-test (e.g. VCR parameters).
         """
         super(TestChainedDatadirTest, self).__init__()
 
@@ -384,6 +386,7 @@ class TestChainedDatadirTest(unittest.TestCase):
         self._chained_tests_method = method_name
         self._artifact_current_destination = artifact_current_destination
         self._save_output = save_output
+        self._extra_test_kwargs = kwargs
 
     def runTest(self):
         """
@@ -433,6 +436,7 @@ class TestChainedDatadirTest(unittest.TestCase):
             artefacts_path=artefacts_path,
             artifact_current_destination=self._artifact_current_destination,
             save_output=self._save_output,
+            **self._extra_test_kwargs,
         )
 
     @staticmethod

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -298,6 +298,11 @@ class VCRDataDirTester(DataDirTester):
                     test_data_dir_class=self._DataDirTester__test_class,
                     artifact_current_destination=self._artifact_current_destination,
                     save_output=self._save_output,
+                    vcr_mode=self.vcr_mode,
+                    vcr_freeze_time=self.vcr_freeze_time,
+                    vcr_sanitizers=self.vcr_sanitizers,
+                    validate_snapshot=self.validate_snapshots,
+                    verbose=self.verbose,
                 )
             else:
                 test = self._DataDirTester__test_class(

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -158,6 +158,8 @@ class VCRTestDataDir(TestDataDir):
         """Run component with VCR wrapping based on mode."""
         if self.vcr_recorder is None:
             logger.warning("Running without VCR (dependencies not available)")
+            if self.vcr_mode == "record":
+                self._merge_secrets_into_config()
             super().run_component()
             return
 

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -194,11 +194,11 @@ class VCRTestDataDir(TestDataDir):
         if self.vcr_recorder is None:
             return
 
-        log_cmp = getattr(self.vcr_recorder, "last_log_comparison", None)
+        log_cmp = self.vcr_recorder.last_log_comparison
         if log_cmp is not None and not log_cmp.success:
             self.fail(f"Log comparison failed:\n{log_cmp.format_output(verbose=self.verbose)}")
 
-        sync_cmp = getattr(self.vcr_recorder, "last_sync_action_comparison", None)
+        sync_cmp = self.vcr_recorder.last_sync_action_comparison
         if sync_cmp is not None and not sync_cmp.success:
             self.fail(f"Sync action output mismatch:\n{sync_cmp.diff}")
 

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -182,11 +182,26 @@ class VCRTestDataDir(TestDataDir):
                     super().run_component()
 
     def compare_source_and_expected(self):
-        """Execute and compare with optional snapshot validation."""
+        """Execute and compare with optional snapshot validation, log comparison, and sync action comparison."""
         super().compare_source_and_expected()
 
         if self.validate_snapshot:
             self._validate_snapshot()
+
+        self._assert_vcr_comparisons()
+
+    def _assert_vcr_comparisons(self):
+        """Fail the test if log or sync action comparisons detected regressions."""
+        if self.vcr_recorder is None:
+            return
+
+        log_cmp = getattr(self.vcr_recorder, "last_log_comparison", None)
+        if log_cmp is not None and not log_cmp.success:
+            self.fail(f"Log comparison failed:\n{log_cmp.format_output(verbose=self.verbose)}")
+
+        sync_cmp = getattr(self.vcr_recorder, "last_sync_action_comparison", None)
+        if sync_cmp is not None and not sync_cmp["success"]:
+            self.fail(f"Sync action output mismatch:\n{sync_cmp['diff']}")
 
     def _validate_snapshot(self):
         """Validate outputs against snapshot if it exists."""

--- a/src/keboola/datadirtest/vcr/tester.py
+++ b/src/keboola/datadirtest/vcr/tester.py
@@ -156,9 +156,6 @@ class VCRTestDataDir(TestDataDir):
 
     def run_component(self):
         """Run component with VCR wrapping based on mode."""
-        if self.vcr_mode == "record":
-            self._merge_secrets_into_config()
-
         if self.vcr_recorder is None:
             logger.warning("Running without VCR (dependencies not available)")
             super().run_component()
@@ -200,8 +197,8 @@ class VCRTestDataDir(TestDataDir):
             self.fail(f"Log comparison failed:\n{log_cmp.format_output(verbose=self.verbose)}")
 
         sync_cmp = getattr(self.vcr_recorder, "last_sync_action_comparison", None)
-        if sync_cmp is not None and not sync_cmp["success"]:
-            self.fail(f"Sync action output mismatch:\n{sync_cmp['diff']}")
+        if sync_cmp is not None and not sync_cmp.success:
+            self.fail(f"Sync action output mismatch:\n{sync_cmp.diff}")
 
     def _validate_snapshot(self):
         """Validate outputs against snapshot if it exists."""


### PR DESCRIPTION
After `super().compare_source_and_expected()`, check `last_log_comparison` and `last_sync_action_comparison` from the VCR recorder and fail the test if either detected a regression.

Depends on: keboola/python-vcr-tests feat/log-capture-sync-actions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/datadirtest/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
